### PR TITLE
pfcp Correct Directory Detection

### DIFF
--- a/scripts/pfcp
+++ b/scripts/pfcp
@@ -26,10 +26,13 @@ def validate_args(parser):
                     error = "All sources for a recursive copy must be" + \
                         " contained within the same directory."
                     raise ArgError
-        if args.dest_path.split()[-1] == "/":
-            base_dest_name = os.path.dirname(args.dest_path)
-        else:
+
+        # if the provided destination is a directory check that it exists
+        # if the provided destination is a file check that it's parent directory exists
+        if args.dest_path[-1] == "/" or os.path.isdir(args.dest_path):
             base_dest_name = args.dest_path
+        else:
+            base_dest_name = os.path.dirname(args.dest_path)
         if base_dest_name and not os.path.exists(base_dest_name):
             error = f"{args.dest_path} - No such file or directory"
             raise ArgError
@@ -262,5 +265,4 @@ if __name__ == "__main__":
         parser.print_usage()
         sys.exit(1)
 
-    
     main(parser)

--- a/scripts/pfscripts.py
+++ b/scripts/pfscripts.py
@@ -270,7 +270,7 @@ class Config:
             # Fall back on the nodes set to ON in pftool.cfg
             nodelist, total_procs = get_nodeallocation()
             if nodelist and total_procs:
-                self.nodelist = nodelist
+                self.node_list = nodelist
                 self.total_procs = total_procs
             else:
                 # get hosts from node list in pftool.cfg


### PR DESCRIPTION
### Problem
pfcp wasn't allowing a destination path with a filename that didn't exist.  

### Solution
pfcp will now check if the destination path ends in a '/' or if the destination path is a directory before deciding whether to check if the destination exists.


Also there was a typo in setting the 'node_list' attribute of the config class.